### PR TITLE
Fixed DescribeRegions call failing. Fixed returning duplicate selectors.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
-utils = github.com/goreleaser/goreleaser \
-		github.com/Masterminds/glide
+utils = github.com/Masterminds/glide
 
 build:
 	go build -i


### PR DESCRIPTION
- Added default region when invoking `DescribeRegions`.
- Added error handler to `DescribeRegions`.
- Added duplicate check when returning selectors.

Fixes #4.